### PR TITLE
Add istat-menus version 5

### DIFF
--- a/Casks/istat-menus5.rb
+++ b/Casks/istat-menus5.rb
@@ -1,4 +1,4 @@
-cask 'istat-menus' do
+cask 'istat-menus5' do
   version '5.32'
   sha256 :no_check # required as upstream package is updated in-place
 

--- a/Casks/istat-menus5.rb
+++ b/Casks/istat-menus5.rb
@@ -1,0 +1,40 @@
+cask 'istat-menus' do
+  version '5.32'
+  sha256 :no_check # required as upstream package is updated in-place
+
+  # amazonaws.com/bjango was verified as official when first introduced to the cask
+  url "https://s3.amazonaws.com/bjango/files/istatmenus#{version.major}/istatmenus#{version}.zip"
+  name 'iStats Menus'
+  homepage 'https://bjango.com/mac/istatmenus/'
+
+  auto_updates true
+
+  app 'iStat Menus.app'
+
+  uninstall delete:    "/Library/Application Support/iStat Menus #{version.major}",
+            launchctl: [
+                         'com.bjango.istatmenusagent',
+                         'com.bjango.istatmenusdaemon',
+                         'com.bjango.istatmenusnotifications',
+                         'com.bjango.istatmenusstatus',
+                       ],
+            signal:    [
+                         ['TERM', 'com.bjango.iStat-Menus-Notifications'],
+                         ['TERM', 'com.bjango.iStatMenusAgent'],
+                         ['TERM', 'com.bjango.istatmenusstatus'],
+                         ['TERM', 'com.bjango.istatmenus'],
+                         ['HUP', 'com.bjango.istatmenus'],
+                       ]
+
+  zap trash: [
+               '~/Library/Application Support/iStat Menus',
+               '~/Library/Caches/com.bjango.istatmenus',
+               '~/Library/Caches/com.bjango.istatmenusstatus',
+               '~/Library/Caches/com.bjango.iStat-Menus-Updater',
+               '~/Library/Caches/com.bjango.iStatMenusAgent',
+               '~/Library/Logs/iStat Menus',
+               '~/Library/Preferences/com.bjango.istatmenus.plist',
+               "~/Library/Preferences/com.bjango.istatmenus#{version.major}.extras.plist",
+               '~/Library/Preferences/com.bjango.istatmenusstatus.plist',
+             ]
+end

--- a/Casks/istat-menus5.rb
+++ b/Casks/istat-menus5.rb
@@ -1,6 +1,6 @@
 cask 'istat-menus5' do
   version '5.32'
-  sha256 :no_check # required as upstream package is updated in-place
+  sha256 'bfb1cd95d119c4248190dc6093147a2b08a04b27b9e57e90638d720f7b2f24c7'
 
   # amazonaws.com/bjango was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/bjango/files/istatmenus#{version.major}/istatmenus#{version}.zip"


### PR DESCRIPTION
Recently Bjango released iStat Menus 6. This brings in iStat Menus 5 for those of us who don't want to upgrade.

This comes from https://github.com/caskroom/homebrew-cask/blob/3a68e11fa578e36fe4745d761a6082b0b158391b/Casks/istat-menus.rb
